### PR TITLE
Add CODEOWNERS file with both users as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global code owners - both users can approve
+* @agentstudio-ai @jnhaffey

--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,2 +1,0 @@
-# Global code owners - only you can approve
-* @agentstudio-ai


### PR DESCRIPTION
## 🔧 Add CODEOWNERS File

### **Changes Made:**
- **Created CODEOWNERS file**: Added `.github/CODEOWNERS` in the correct location
- **Removed old CODEOWNERS**: Deleted `.github/workflows/CODEOWNERS` from incorrect location
- **Added code owners**: Both `@agentstudio-ai` and `@jnhaffey` are now code owners for all files

### **Impact:**
- Both `@agentstudio-ai` and `@jnhaffey` can now approve PRs
- Both users will be able to bypass branch protection once settings are updated
- CODEOWNERS file is now in the correct location for GitHub to recognize it

### **Next Steps:**
After this PR is merged, the branch protection settings should be updated to:
1. Enable "Require review from code owners"
2. Enable "Allow specified actors to bypass required pull requests"
3. Add both users to the bypass list

This will allow both code owners to push directly to `dev` while maintaining PR requirements for other users.

### **Files Changed:**
- `.github/CODEOWNERS` (created in correct location)
- `.github/workflows/CODEOWNERS` (deleted from incorrect location)
